### PR TITLE
Reset filter checks on generate

### DIFF
--- a/app/ProfanityFilter.php
+++ b/app/ProfanityFilter.php
@@ -148,6 +148,8 @@ class ProfanityFilter
 
     private function generateFilterChecks()
     {
+        $this->filterChecks = [];
+
         foreach ($this->badWords as $string) {
             $this->filterChecks[] = $this->getFilterRegexp($string);
         }


### PR DESCRIPTION
This PR prevents invalid filter checks to be appended, causing conflict with `$replaceFullWords` config.